### PR TITLE
Explicit object type parsing

### DIFF
--- a/eventio/iact/__init__.py
+++ b/eventio/iact/__init__.py
@@ -4,7 +4,6 @@ import numpy as np
 from collections import namedtuple
 from .exceptions import WrongTypeException
 log = logging.getLogger(__name__)
-from .objects import parse_eventio_object
 from .. import object_tree
 
 def sort_objects_into_showers(objects):
@@ -43,12 +42,12 @@ def generate_event(shower):
         - IACTPhotons(more than one or even zero)
         - CorsikaEventEndBlock(exactly 1)
     '''
-    header = parse_eventio_object(shower[0])
-    array_offsets = parse_eventio_object(shower[1])
-    end_block = parse_eventio_object(shower[-1])
+    header = objects.make_CorsikaEventHeader(shower[0])
+    array_offsets = objects.make_CorsikaArrayOffsets(shower[1])
+    end_block = objects.make_CorsikaEventEndBlock(shower[-1])
 
     for reuse_event in shower[2:-1]:
-        telescope_events = parse_eventio_object(reuse_event)
+        telescope_events = objects.make_TelescopeEvents(reuse_event)
         corsika_events = []
         for photon_bunches in telescope_events:
             corsika_events.append(CorsikaEvent(
@@ -106,10 +105,10 @@ class IACTFile:
 
     def __init__(self, file):
         self.objects = object_tree(file)
-        self.run_header = parse_eventio_object(self.objects[0])
-        self.input_card= parse_eventio_object(self.objects[1])
-        self.telescope_definition = parse_eventio_object(self.objects[2])
-        self.end_block = parse_eventio_object(self.objects[-1])
+        self.run_header = objects.make_CorsikaRunHeader(self.objects[0])
+        self.input_card= objects.make_CorsikaInputCard(self.objects[1])
+        self.telescope_definition = objects.make_CorsikaTelescopeDefinition(self.objects[2])
+        self.end_block = objects.make_CorsikaRunEndBlock(self.objects[-1])
         self.n_telescopes = self.telescope_definition.n_telescopes
         self.telescope_positions = self.telescope_definition.tel_pos
         self.showers = sort_objects_into_showers(self.objects[3:-1])

--- a/eventio/iact/tests/test_iact_objects.py
+++ b/eventio/iact/tests/test_iact_objects.py
@@ -3,18 +3,16 @@ import pkg_resources
 from os import path
 
 from pytest import approx
+import eventio.iact.objects as objects
 
 testfile_path = pkg_resources.resource_filename(
     'eventio', path.join('resources', 'one_shower.dat')
 )
 
 def test_corsica_event_header():
-    from eventio.iact.parse_corsika_data import CorsikaEventHeader
-    from eventio.iact.objects import parse_eventio_object
-
     with open(testfile_path, 'rb') as testfile:
         f = eventio.object_tree(testfile)
-        event_header = parse_eventio_object(f[3])
+        event_header = objects.make_CorsikaEventHeader(f[3])
 
         assert event_header.event_id == 1
         assert event_header.zenith_angle == approx(0.0)
@@ -24,10 +22,9 @@ def test_corsica_event_header():
 
 
 def test_telescope_definition():
-    from eventio.iact.objects import parse_eventio_object
     with open(testfile_path, 'rb') as testfile:
         f = eventio.object_tree(testfile)
-        telescope_definition = parse_eventio_object(f[2])
+        telescope_definition = objects.make_CorsikaTelescopeDefinition(f[2])
 
         assert telescope_definition.n_telescopes == 1
         assert telescope_definition.tel_pos['x'][0] == approx(0.0)
@@ -38,10 +35,9 @@ def test_telescope_definition():
 
 
 def test_corsica_array_offsets():
-    from eventio.iact.objects import parse_eventio_object
     with open(testfile_path, 'rb') as testfile:
         f = eventio.object_tree(testfile)
-        offsets_object = parse_eventio_object(f[4])
+        offsets_object = objects.make_CorsikaArrayOffsets(f[4])
 
         assert len(offsets_object.offsets) == 1
         assert offsets_object.offsets['x'][0] == approx(-506.9717102050781)
@@ -49,10 +45,9 @@ def test_corsica_array_offsets():
 
 
 def test_event_has_382_bunches():
-    from eventio.iact.objects import parse_eventio_object
     with open(testfile_path, 'rb') as testfile:
         f = eventio.object_tree(testfile)
-        telescope_events = parse_eventio_object(f[5])
+        telescope_events = objects.make_TelescopeEvents(f[5])
         assert len(telescope_events) == 1
 
         bunches = telescope_events[0]
@@ -60,10 +55,9 @@ def test_event_has_382_bunches():
 
 
 def test_bunches():
-    from eventio.iact.objects import parse_eventio_object
     with open(testfile_path, 'rb') as testfile:
         f = eventio.object_tree(testfile)
-        telescope_events = parse_eventio_object(f[5])
+        telescope_events = objects.make_TelescopeEvents(f[5])
         assert len(telescope_events) == 1
 
         bunches = telescope_events[0]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='eventio',
-    version='0.3.0',
+    version='0.3.1',
     description='Python read-only implementation of the EventIO file format',
     url='https://github.com/fact-project/pyeventio',
     author='Dominik Neise, Maximilian Noethe',


### PR DESCRIPTION
This PR intends to modify a higher level API.

So when somebody wants to decrypt a raw object_tree into a more usable data structure, the person has assumptions about that object_tree. As in, the first object has always type 1337 and the last always type 42. Whatever.

So when implementing such higher level stuff, the developer should specify as explicitly as possible, what the expectations are, so readers of the code, can understand what is going on.
