### PR TITLE
parse SimTelRunHeader into dict (via numpy rec-arrays).

### DIFF
--- a/eventio/simtel/runheader_dtypes.py
+++ b/eventio/simtel/runheader_dtypes.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+runheader_dtype_part1 = np.dtype([
+    #(fieldname, type, shape)
+    ('run', 'i4'),
+    ('time', 'i4'),
+    ('run_type', 'i4'),
+    ('tracking_mode', 'i4'),
+    ('reverse_flag', 'i4'),
+    ('direction', 'f4', (2,)),
+    ('offset_fov', 'f4', (2,)),
+    ('conv_depth', 'f4'),
+    ('conv_ref_pos', 'f4', (2,)),
+    ('ntel', 'i4'),
+])
+
+def runheader_dtype_part2(ntel):
+    return np.dtype([
+        #(fieldname, type, shape)
+        ('tel_id', 'i2', (ntel,)),
+        ('tel_pos', 'f4', (ntel, 3)),
+        ('min_tel_trig', 'i4'),
+        ('duration', 'i4', ),
+        ('spectral_index', 'f4'),
+        ('B_total', 'f4'),
+        ('B_inclination', 'f4'),
+        ('B_declination', 'f4'),
+        ('injection_height', 'f4'),
+        ('atmosphere', 'i4'),
+    ])
+


### PR DESCRIPTION
Playing around with this like:
```
In [1]: import eventio
   ...: f = eventio.EventIOFile('gamma_test.simtel.gz')
   ...: for o in f:
   ...:     if o.header.type == 2000:
   ...:         break
   ...: o.parse_data_field()
```

result is a dict

 * I believe the time should be converted into a real datetime 
 * I think the `run_type` should be an enum:

Docu for `run_type`:
```
   int run_type;             ///< Data/pedestal/laser/muon run or MC run:
                             ///<   MC run: -1,
                             ///<   Data run: 1,
                             ///<   Pedestal run: 2,
                             ///<   Laser run: 3,
                             ///<   Muon run: 4.
```

No time to work on this for the next hours. Feel free to go on with this. 

