### PR TITLE
Read next header interface

### DIFF
--- a/eventio/base.py
+++ b/eventio/base.py
@@ -94,7 +94,8 @@ def read_next_header(byte_stream, endianness=None):
 
     Raises stop iteration if not enough data is available.
     '''
-    if endianness is None:
+    is_toplevel_object = endianness is None
+    if is_toplevel_object:
         sync = byte_stream.read(constants.SYNC_MARKER_SIZE)
         check_size_or_stopiteration(sync, constants.SYNC_MARKER_SIZE)
         endianness = parse_sync_bytes(sync)
@@ -108,7 +109,7 @@ def read_next_header(byte_stream, endianness=None):
     check_size_or_stopiteration(
         header_bytes,
         constants.OBJECT_HEADER_SIZE,
-        warn_zero=endianness is None,
+        warn_zero=is_toplevel_object,
     )
 
     header = parse_header_bytes(header_bytes)
@@ -116,7 +117,11 @@ def read_next_header(byte_stream, endianness=None):
 
     if header.extended:
         extension_field = byte_stream.read(constants.EXTENSION_SIZE)
-        check_size_or_stopiteration(extension_field, constants.EXTENSION_SIZE, True)
+        check_size_or_stopiteration(
+            extension_field,
+            constants.EXTENSION_SIZE,
+            warn_zero=True
+        )
         header.length += parse_extension_field(extension_field)
 
     header.data_field_first_byte = byte_stream.tell()

--- a/eventio/base.py
+++ b/eventio/base.py
@@ -92,6 +92,10 @@ def read_next_header(byte_stream, endianness=None):
     '''Read the next header object from the file
     Assumes position of `byte_stream` is at the beginning of a new header.
 
+    endianness: char
+        '<' or '>' for little or big endiannes respectively.
+        Is either read from next header or already known.
+
     Raises stop iteration if not enough data is available.
     '''
     is_toplevel_object = endianness is None

--- a/eventio/simtel/objects.py
+++ b/eventio/simtel/objects.py
@@ -1,7 +1,7 @@
 ''' Implementations of the simtel_array EventIO object types '''
 import numpy as np
 import struct
-from ..base import EventIOObject, read_next_header
+from ..base import EventIOObject, read_next_header_sublevel
 from ..tools import (
     read_short,
     read_int,
@@ -1078,7 +1078,7 @@ class SimTelMCShower(EventIOObject):
             mc['profiles'].append(p)
 
         if self.header.version >= 2:
-            h = read_next_header(self, toplevel=False)
+            h = read_next_header_sublevel(self)
             assert h.type == 1215
             mc['mc_extra_params'] = MC_Extra_Params(h, self).parse_data_field()
         return mc


### PR DESCRIPTION
I think the function `read_next_header` had a too difficult interface. It was unclear what the first parameter `eventio` really was. was it a stream of bytes? (I had `read` and `tell`) .. or was it something else (it had `.header.endianness`).

I (hopefully) cleaned this interface by using a byte_stream as first parameter ... 

The second boolean parameter, should be avoided, since functions with a boolean paramter often simply hide two functions inside and this violates the single responsibility principle.

So I split it into two functions.

----

Inside `read_next_header` there is a function used named `check_size_or_stopiteration(data, expected_length, warn_zero`).

The value of warn_zero depended on whether one was parsing a toplevel or a sublevel header... I did not understand this. Also this warning is an untested feature .. I hate having untested features .. if a user depends on this warning beeing printed on the screen we should test it ... 

So anyway now I decided to always warn .. why not .. if something happens what we do not understand we should warn I think
