### PR TITLE
Add new types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,21 +12,29 @@ Most blocks of the IACT extension and SimTel are implemented.
 The following blocks are known, but reading their data is not (yet)
 implemented:
 
-+--------+-----------------------+
-| Code   | Description           |
-+========+=======================+
-| 1206   | IACT Layout           |
-+--------+-----------------------+
-| 1207   | IACT Trigger Time     |
-+--------+-----------------------+
-| 2017   | SimTel PixelCalib     |
-+--------+-----------------------+
-| 2024   | SimTel RunStat        |
-+--------+-----------------------+
-| 2025   | SimTel MC_RunStat     |
-+--------+-----------------------+
-| 2028   | SimTel CalibEvent     |
-+--------+-----------------------+
++--------+-------------------------------+
+| Code   | Description                   |
++========+===============================+
+| 1206   | IACT Layout                   |
++--------+-------------------------------+
+| 1207   | IACT Trigger Time             |
++--------+-------------------------------+
+| 2017   | SimTel PixelCalib             |
++--------+-------------------------------+
+| 2024   | SimTel RunStat                |
++--------+-------------------------------+
+| 2025   | SimTel MC_RunStat             |
++--------+-------------------------------+
+| 2028   | SimTel CalibEvent             |
++--------+-------------------------------+
+| 2029   | SimTel AuxiliaryDigitalTraces |
++--------+-------------------------------+
+| 2030   | SimTel AuxiliaryAnalogTraces  |
++--------+-------------------------------+
+| 2031   | SimTel FSPhot                 |
++--------+-------------------------------+
+| 2032   | SimTel PixelTriggerTimes      |
++--------+-------------------------------+
 
 
 install with

--- a/eventio/simtel/objects.py
+++ b/eventio/simtel/objects.py
@@ -1477,7 +1477,7 @@ class FSPhot(EventIOObject):
     eventio_type = 2031
 
 
-class PixelTriggerTime(TelescopeEvent):
+class PixelTriggerTimes(TelescopeEvent):
     eventio_type = 2032
 
 

--- a/eventio/simtel/objects.py
+++ b/eventio/simtel/objects.py
@@ -1463,6 +1463,24 @@ class CalibrationEvent(EventIOObject):
     eventio_type = 2028
 
 
+class AuxiliaryDigitalTraces(EventIOObject):
+    eventio_type = 2029
+
+
+class AuxiliaryAnalogTraces(EventIOObject):
+    eventio_type = 2030
+
+
+class FSPhot(EventIOObject):
+    '''No idea what this should be, it's only defined in io_hess.h, no
+    code that actually reads or writes this type'''
+    eventio_type = 2031
+
+
+class PixelTriggerTime(TelescopeEvent):
+    eventio_type = 2032
+
+
 def merge_structured_arrays_into_dict(arrays):
     result = dict()
     for array in arrays:

--- a/eventio/simtel/tests/test_simtel_objects.py
+++ b/eventio/simtel/tests/test_simtel_objects.py
@@ -594,6 +594,27 @@ def test_2027_3_objects():
     }
     '''
 
+
 @pytest.mark.xfail
 def test_2028():
+    assert False
+
+
+@pytest.mark.xfail
+def test_2029():
+    assert False
+
+
+@pytest.mark.xfail
+def test_2030():
+    assert False
+
+
+@pytest.mark.xfail
+def test_2031():
+    assert False
+
+
+@pytest.mark.xfail
+def test_2032():
     assert False


### PR DESCRIPTION
I found a couple of new types in `io_hess.h` (the one in this repo). 

One of them appears in our prod4 files (type 2032, `PixelTriggerTimes`)